### PR TITLE
fix(raf-state): accumulate updates passed between repaints

### DIFF
--- a/packages/react-use/src/use-raf-state/index.test.ts
+++ b/packages/react-use/src/use-raf-state/index.test.ts
@@ -32,35 +32,40 @@ describe('useRafState', () => {
     expect(result.current[0]).toBe(1)
   })
 
-  it('should handle multiple updates correctly', () => {
-    const { result } = renderHook(() => useRafState(initialState))
-
-    act(() => {
-      result.current[1](2)
-      result.current[1](3)
-    })
-    act(() => {
-      vi.advanceTimersToNextFrame()
-    })
-
-    expect(result.current[0]).toBe(3)
-  })
-
   it('should work with undefined initial state', () => {
     const { result } = renderHook(() => useRafState())
     expect(result.current[0]).toBeUndefined()
   })
 
-  it('should update state with a function', () => {
+  it.each([
+    {
+      name: 'value updates',
+      updates: [2, 3],
+      expected: 3,
+    },
+    {
+      name: 'function updates',
+      updates: [(prev: number) => prev + 2, (prev: number) => prev + 1],
+      expected: 3,
+    },
+    {
+      name: 'mixed updates',
+      updates: [2, (prev: number) => prev + 1],
+      expected: 3,
+    },
+  ])('should handle multiple updates correctly > $name', ({ updates, expected }) => {
     const { result } = renderHook(() => useRafState(initialState))
 
     act(() => {
-      result.current[1]((prev) => prev + 1)
+      const [_, setState] = result.current
+      for (const update of updates) {
+        setState(update)
+      }
     })
     act(() => {
       vi.advanceTimersToNextFrame()
     })
 
-    expect(result.current[0]).toBe(1)
+    expect(result.current[0]).toBe(expected)
   })
 })


### PR DESCRIPTION
Currently, updates scheduled via `useRafState` are deferred to the next frame, canceling previously scheduled update. If multiple function updates (e.g. `setState(prev => prev + 1)`) occur between repaint cycles, only the last update is executed, and previous intermediate state transitions are lost.

In the [**demo**](https://codesandbox.io/p/sandbox/use-raf-state-demo-3d3s2w), the `double` callback should increment the counter twice by calling `setCount((v) => v + 1)` two times. However, only the last call is actually executed on the repaint, so instead of resulting in `+2`, it results in `+1`.

## What was changed

- fixed `useRafState` to accumulate state changes and only set the final state value on repaint (next frame)
- refactored update state tests into a parameterized suite (value, function, and mixed updates)